### PR TITLE
Fix group restriction incorrect report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.darvil"
-version = "0.2.0"
+version = "0.2.1"
 description = "Command line argument parser"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ description = "Command line argument parser"
 
 dependencies {
 	implementation("com.darvil:utils:0.0.2")
-	implementation("com.darvil:terminal-text-formatter:0.0.5")
+	implementation("com.darvil:terminal-text-formatter:1.0.0")
 
 	implementation("org.jetbrains:annotations:24.0.1")
 	testImplementation(platform("org.junit:junit-bom:5.9.1"))

--- a/src/main/java/lanat/helpRepresentation/ArgumentGroupRepr.java
+++ b/src/main/java/lanat/helpRepresentation/ArgumentGroupRepr.java
@@ -32,7 +32,7 @@ public final class ArgumentGroupRepr {
 			return null;
 
 		final var name = new TextFormatter(group.getName() + ':').addFormat(FormatOption.BOLD);
-		if (group.isExclusive())
+		if (group.isRestricted())
 			name.addFormat(FormatOption.UNDERLINE);
 
 		return '\n' + name.toString() + '\n' + HelpFormatter.indent(description, group);
@@ -62,7 +62,7 @@ public final class ArgumentGroupRepr {
 		if (description == null && argumentDescriptions.isEmpty())
 			return "";
 
-		if (group.isExclusive())
+		if (group.isRestricted())
 			name.addFormat(FormatOption.UNDERLINE);
 
 		if (description != null)
@@ -92,8 +92,8 @@ public final class ArgumentGroupRepr {
 		// its empty, nothing to append
 		if (group.isEmpty()) return "";
 
-		// if this group isn't exclusive, we just want to append the arguments, basically
-		if (group.isExclusive())
+		// if this group isn't restricted, we just want to append the arguments, basically
+		if (group.isRestricted())
 			buff.append('(');
 
 		final var arguments = Argument.sortByPriority(group.getArguments());
@@ -103,7 +103,7 @@ public final class ArgumentGroupRepr {
 			buff.append(ArgumentRepr.getRepresentation(arg));
 			if (i < arguments.size() - 1) {
 				buff.append(' ');
-				if (group.isExclusive())
+				if (group.isRestricted())
 					buff.append('|').append(' ');
 			}
 		}
@@ -112,7 +112,7 @@ public final class ArgumentGroupRepr {
 
 		if (!arguments.isEmpty() && !groups.isEmpty()) {
 			buff.append(' ');
-			if (group.isExclusive())
+			if (group.isRestricted())
 				buff.append("| ");
 		}
 
@@ -121,12 +121,12 @@ public final class ArgumentGroupRepr {
 			buff.append(ArgumentGroupRepr.getRepresentation(grp)); // append the group's representation recursively
 			if (i < groups.size() - 1) {
 				buff.append(' ');
-				if (grp.isExclusive())
+				if (grp.isRestricted())
 					buff.append('|').append(' ');
 			}
 		}
 
-		if (group.isExclusive())
+		if (group.isRestricted())
 			buff.append(')');
 
 		return buff.toString();

--- a/src/main/java/lanat/parsing/errors/ParseErrors.java
+++ b/src/main/java/lanat/parsing/errors/ParseErrors.java
@@ -152,11 +152,11 @@ public abstract class ParseErrors {
 	}
 
 	/**
-	 * Error that occurs when multiple arguments in an exclusive group are used.
+	 * Error that occurs when multiple arguments in a restricted group are used.
 	 * @param indicesPair The indices of the tokens that caused the error. (start, end)
-	 * @param group The exclusive group that contains the arguments.
+	 * @param group The restricted group that contains the arguments.
 	 */
-	public record MultipleArgsInExclusiveGroupUsedError(
+	public record MultipleArgsInRestrictedGroupUsedError(
 		@NotNull Pair<Integer, Integer> indicesPair,
 		@NotNull ArgumentGroup group
 	) implements Error.ParseError
@@ -164,7 +164,7 @@ public abstract class ParseErrors {
 		@Override
 		public void handle(@NotNull ErrorFormattingContext fmt, @NotNull ParseErrorContext ctx) {
 			fmt
-				.withContent("Multiple arguments in exclusive group '" + this.group.getName() + "' used.")
+				.withContent("Multiple arguments in restricted group '" + this.group.getName() + "' used.")
 				.highlight(this.indicesPair.first(), this.indicesPair.second(), false);
 		}
 	}

--- a/src/test/java/lanat/test/UnitTests.java
+++ b/src/test/java/lanat/test/UnitTests.java
@@ -82,8 +82,8 @@ public class UnitTests {
 			this.addCommand(new Command("subCommand2") {{
 				this.setErrorCode(0b1000);
 
-				this.addGroup(new ArgumentGroup("exclusive-group") {{
-					this.setExclusive(true);
+				this.addGroup(new ArgumentGroup("restricted-group") {{
+					this.setRestricted(true);
 					this.addArgument(Argument.createOfBoolType("extra"));
 					this.addArgument(Argument.create(new IntegerArgumentType(), 'c').positional());
 				}});

--- a/src/test/java/lanat/test/exampleTests/CommandTemplateExample.java
+++ b/src/test/java/lanat/test/exampleTests/CommandTemplateExample.java
@@ -61,7 +61,7 @@ public class CommandTemplateExample extends CommandTemplate.Default {
 	@InitDef
 	public static void afterInit(@NotNull Command cmd) {
 		cmd.addGroup(new ArgumentGroup("test-group") {{
-			this.setExclusive(true);
+			this.setRestricted(true);
 			this.addArgument(cmd.getArgument("string"));
 			this.addArgument(cmd.getArgument("number"));
 		}});

--- a/src/test/java/lanat/test/exampleTests/ExampleTest.java
+++ b/src/test/java/lanat/test/exampleTests/ExampleTest.java
@@ -15,7 +15,7 @@ public final class ExampleTest {
 	@Test
 	public void main() {
 		Argument.PrefixChar.defaultPrefix = Argument.PrefixChar.MINUS;
-		HelpFormatter.lineWrapMax = 80;
+//		HelpFormatter.lineWrapMax = 80;
 //		TextFormatter.enableSequences = false;
 //		ErrorFormatter.errorFormatterClass = SimpleErrorFormatter.class;
 

--- a/src/test/java/lanat/test/exampleTests/ExampleTest.java
+++ b/src/test/java/lanat/test/exampleTests/ExampleTest.java
@@ -5,7 +5,6 @@ import lanat.argumentTypes.CounterArgumentType;
 import lanat.argumentTypes.IntegerArgumentType;
 import lanat.argumentTypes.MultipleStringsArgumentType;
 import lanat.argumentTypes.NumberRangeArgumentType;
-import lanat.helpRepresentation.HelpFormatter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/lanat/test/exampleTests/ExampleTest.java
+++ b/src/test/java/lanat/test/exampleTests/ExampleTest.java
@@ -5,6 +5,7 @@ import lanat.argumentTypes.CounterArgumentType;
 import lanat.argumentTypes.IntegerArgumentType;
 import lanat.argumentTypes.MultipleStringsArgumentType;
 import lanat.argumentTypes.NumberRangeArgumentType;
+import lanat.helpRepresentation.HelpFormatter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -14,22 +15,26 @@ public final class ExampleTest {
 	@Test
 	public void main() {
 		Argument.PrefixChar.defaultPrefix = Argument.PrefixChar.MINUS;
+		HelpFormatter.lineWrapMax = 80;
 //		TextFormatter.enableSequences = false;
 //		ErrorFormatter.errorFormatterClass = SimpleErrorFormatter.class;
 
 		var ap = new ArgumentParser("my-program") {{
 			this.setCallbackInvocationOption(CallbacksInvocationOption.NO_ERROR_IN_ARGUMENT);
+			this.setDescription("This is the description of my program. What do you think about it? Oh by the way, don't forget to use the <link=args.user> argument!");
+			this.setLicense("Here's some more extra information about my program. Really don't know how to fill this out...");
 			this.addHelpArgument();
 			this.addArgument(Argument.create(new CounterArgumentType(), "counter", "c").onOk(System.out::println));
-			this.addArgument(Argument.create(new Example1Type(), "user", "u").required().positional());
+			this.addArgument(Argument.create(new Example1Type(), "user", "u").required().positional().withDescription("Specify the user/s to use."));
 			this.addArgument(Argument.createOfBoolType("t").onOk(v -> System.out.println("present")));
-			this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println));
+			this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println).withDescription("The value that matters the most (not really). Hey, this thing is generated automatically as well!: <desc=!.type>"));
 			this.addArgument(Argument.create(new MultipleStringsArgumentType(Range.from(3).to(5)), "string", "s").onOk(System.out::println).withPrefix(Argument.PrefixChar.PLUS));
 			this.addArgument(Argument.create(new IntegerArgumentType(), "test").onOk(System.out::println).allowsUnique());
 
 			this.addCommand(new Command("sub1", "testing") {{
 				this.addArgument(Argument.create(new IntegerArgumentType(), "required").required().positional());
 				this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println));
+				this.setDescription("Now this is the description of the subcommand inside the main command.");
 				this.addCommand(new Command("sub2", "testing") {{
 					this.addArgument(Argument.create(new IntegerArgumentType(), "required").required().positional());
 					this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println));
@@ -37,8 +42,7 @@ public final class ExampleTest {
 			}});
 		}};
 
-		ap.parse(CLInput.from("josh ! --number 2 '-cccc ++string [test1 "
-				+ "test2 t2] -ccc sub1 --required 1 --number 121 sub2 2 --number [4]"))
+		ap.parse(CLInput.from("josh ! --number 2 sub1 --required 1 --number 121"))
 			.printErrors()
 			.getParsedArguments();
 	}

--- a/src/test/java/lanat/test/units/TestArgumentGroups.java
+++ b/src/test/java/lanat/test/units/TestArgumentGroups.java
@@ -15,7 +15,7 @@ public class TestArgumentGroups extends UnitTests {
 		final var parser = super.setParser();
 
 		parser.addGroup(new ArgumentGroup("group") {{
-			this.setExclusive(true);
+			this.setRestricted(true);
 			this.addArgument(Argument.createOfBoolType("group-arg"));
 			this.addArgument(Argument.createOfBoolType("group-arg2"));
 		}});
@@ -24,8 +24,8 @@ public class TestArgumentGroups extends UnitTests {
 	}
 
 	@Test
-	@DisplayName("Test exclusive group")
-	public void testExclusiveGroup() {
+	@DisplayName("Test restricted group")
+	public void testRestrictedGroup() {
 		var parsedArgs = this.parser.parseGetValues("--group-arg --group-arg2");
 		assertEquals(Boolean.TRUE, parsedArgs.<Boolean>get("group-arg").orElse(null));
 		assertEquals(Boolean.FALSE, parsedArgs.<Boolean>get("group-arg2").orElse(null)); // group-arg2 should not be present

--- a/src/test/java/lanat/test/units/TestTerminalOutput.java
+++ b/src/test/java/lanat/test/units/TestTerminalOutput.java
@@ -119,12 +119,12 @@ public class TestTerminalOutput extends UnitTests {
 	}
 
 	@Test
-	@DisplayName("Test group exclusivity error")
-	public void testGroupExclusivityError() {
+	@DisplayName("Test group restriction error")
+	public void testGroupRestrictionError() {
 		this.assertErrorOutput("foo subCommand2 --extra --c 5", """
 			ERROR
 			Testing foo subCommand2 --extra -> --c 5 <-
-			Multiple arguments in exclusive group 'exclusive-group' used.""");
+			Multiple arguments in restricted group 'restricted-group' used.""");
 	}
 
 	@Test


### PR DESCRIPTION
* Bump terminal formatter to latest.
* Fix restricted groups incorrectly throwing errors for usage violations that do not occur.
* Rename "exclusive" groups to "restricted".