### PR TITLE
Add utility methods in ParsedArguments and in Command Templates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 		implementation(s + ":javadoc")
 	}
 
-	implWithJavadoc("com.darvil:utils:0.0.2")
+	implWithJavadoc("com.darvil:utils:0.1.0")
 	implWithJavadoc("com.darvil:terminal-text-formatter:1.0.0")
 
 	implementation("org.jetbrains:annotations:24.0.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,13 @@ version = "0.2.1"
 description = "Command line argument parser"
 
 dependencies {
-	implementation("com.darvil:utils:0.0.2")
-	implementation("com.darvil:terminal-text-formatter:1.0.0")
+	val implWithJavadoc = { s: String ->
+		implementation(s)
+		implementation(s + ":javadoc")
+	}
+
+	implWithJavadoc("com.darvil:utils:0.0.2")
+	implWithJavadoc("com.darvil:terminal-text-formatter:1.0.0")
 
 	implementation("org.jetbrains:annotations:24.0.1")
 	testImplementation(platform("org.junit:junit-bom:5.9.1"))

--- a/src/main/java/lanat/Argument.java
+++ b/src/main/java/lanat/Argument.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
  * <p>
  * An Argument specifies a value that the user can introduce to the command. This value will be parsed by the specified
  * {@link ArgumentType} each time the Argument is used. Once finished parsing, the value may be retrieved by using
- * {@link ParsedArguments#get(String)} on the {@link ParsedArguments} object returned by
+ * {@link ParseResult#get(String)} on the {@link ParseResult} object returned by
  * {@link ArgumentParser#parse(CLInput)}.
  *
  * <p>
@@ -750,5 +750,3 @@ public class Argument<Type extends ArgumentType<TInner>, TInner>
 		this.onErrorCallback.accept(this);
 	}
 }
-
-

--- a/src/main/java/lanat/Argument.java
+++ b/src/main/java/lanat/Argument.java
@@ -276,8 +276,8 @@ public class Argument<Type extends ArgumentType<TInner>, TInner>
 	 * names.
 	 * <br><br>
 	 * <p>
-	 * Single character names can be used in argument name lists (e.g. <code>-abc</code>), each alphabetic character
-	 * being an argument name, that is, <code>-a -b -c</code>.
+	 * Single character names can be used in argument name lists (e.g. {@code -abc}), each alphabetic character
+	 * being an argument name, that is, {@code -a -b -c}.
 	 * </p>
 	 *
 	 * @param names the names that should be added to this argument.
@@ -463,8 +463,8 @@ public class Argument<Type extends ArgumentType<TInner>, TInner>
 	/**
 	 * Checks if this argument matches the given name, including the prefix.
 	 * <p>
-	 * For example, if the prefix is <code>'-'</code> and the argument has the name <code>"help"</code>, this method
-	 * will return {@code true} if the name is <code>"--help"</code>.
+	 * For example, if the prefix is {@code '-'} and the argument has the name {@code "help"}, this method
+	 * will return {@code true} if the name is {@code "--help"}.
 	 * </p>
 	 *
 	 * @param name the name to check
@@ -651,7 +651,7 @@ public class Argument<Type extends ArgumentType<TInner>, TInner>
 		 * <p>
 		 * <strong>NOTE:<br></strong>
 		 * The constant fields of this class should be used instead of this method. Other characters could break
-		 * compatibility with shells using special characters as prefixes, such as the <code>|</code> or <code>;</code>
+		 * compatibility with shells using special characters as prefixes, such as the {@code |} or {@code ;}
 		 * characters.
 		 * </p>
 		 *

--- a/src/main/java/lanat/ArgumentParser.java
+++ b/src/main/java/lanat/ArgumentParser.java
@@ -413,6 +413,7 @@ public class ArgumentParser extends Command {
 					AfterParseOptions.into$handleCommandAccessor(instance, commandAccesorField, parsedArgs);
 				});
 
+			instance.afterInstantiation(parsedArgs);
 			return instance;
 		}
 

--- a/src/main/java/lanat/ArgumentParser.java
+++ b/src/main/java/lanat/ArgumentParser.java
@@ -23,13 +23,14 @@ import java.util.stream.Stream;
  * <h2>Argument Parser</h2>
  * <p>
  * Provides the ability to parse a command line input and later gather the values of the parsed arguments.
+ * @see Command
  */
 public class ArgumentParser extends Command {
+	/** This is used to be able to tell if we should reset the state of all the commands before parsing */
 	private boolean isParsed = false;
 	private @Nullable String license;
 	private @Nullable String version;
 
-	// TODO: match constructor javadocs here with the ones in Command
 	/**
 	 * Creates a new command with the given name and description.
 	 * @param programName The name of the command. This is the name the user will use to indicate that they want to use this
@@ -52,17 +53,27 @@ public class ArgumentParser extends Command {
 
 	/**
 	 * Creates a new command based on the given {@link CommandTemplate}. This does not take Sub-Commands into account.
-	 * If you want to add Sub-Commands, use {@link #from(Class)} instead.
+	 * If you want to add Sub-Commands, use {@link ArgumentParser#from(Class)} instead.
 	 * @param templateClass The class of the template to use.
+	 * @see CommandTemplate
 	 */
 	public ArgumentParser(@NotNull Class<? extends CommandTemplate> templateClass) {
 		super(templateClass);
 	}
 
-	// TODO: add info about the code comparison between using from() and not using it
 	/**
 	 * Constructs a new {@link ArgumentParser} based on the given {@link CommandTemplate}, taking Sub-Commands into
 	 * account.
+	 * <p>
+	 * This is basically a shortcut for the following code:
+	 * <pre>{@code
+	 * new ArgumentParser(clazz) {{
+	 *     this.addCommand(new Command(subCmdClazz)); // do this for all possible sub-commands
+	 * }};
+	 * }</pre>
+	 * This method basically makes it easier to add Sub-Commands to the given {@link CommandTemplate}. It looks for
+	 * {@link lanat.CommandTemplate.CommandAccessor} annotations in the given class and adds the corresponding
+	 * sub-commands to the {@link Command} object. This is done recursively.
 	 * @param templateClass The class of the {@link CommandTemplate} to use.
 	 * @return A new {@link ArgumentParser} based on the given {@link CommandTemplate}.
 	 * @see CommandTemplate
@@ -82,14 +93,12 @@ public class ArgumentParser extends Command {
 	 * <p>
 	 * This is basically a shortcut for the following code:
 	 * <pre>{@code
-	 * new ArgumentParser(clazz).parse(input).into(clazz);
+	 * ArgumentParser.from(clazz).parse(input).into(clazz);
 	 * }</pre>
 	 * <h4>Example:</h4>
 	 * This code:
 	 * <pre>{@code
-	 * MyTemplate parsed = new ArgumentParser(MyTemplate.class) {{
-	 *     addCommand(new Command(MyTemplate.SubTemplate.class));
-	 * }}
+	 * ArgumentParser.from(MyTemplate.class)
 	 *     .parse(input)
 	 *     .printErrors()
 	 *     .exitIfErrors()
@@ -101,7 +110,10 @@ public class ArgumentParser extends Command {
 	 * MyTemplate parsed = ArgumentParser.parseFromInto(MyTemplate.class, input);
 	 * }
 	 * </pre>
-	 *
+	 * The example above uses the {@link #parseFromInto(Class, CLInput)} overload, which sets the default options for
+	 * the {@link AfterParseOptions} object.
+	 * <p>
+	 * This method uses {@link #from(Class)}. See that method for more info.
 	 * @param templateClass The class to use as a template.
 	 * @param input The input to parse.
 	 * @param options A consumer that can be used for configuring the parsing process.
@@ -109,6 +121,8 @@ public class ArgumentParser extends Command {
 	 * @return The parsed template.
 	 * @see #parseFromInto(Class, CLInput)
 	 * @see CommandTemplate
+	 * @see #from(Class)
+	 * @see AfterParseOptions
 	 */
 	public static <T extends CommandTemplate> @NotNull T parseFromInto(
 		@NotNull Class<T> templateClass,
@@ -125,12 +139,14 @@ public class ArgumentParser extends Command {
 	/**
 	 * Constructs a new {@link ArgumentParser} based on the given {@link CommandTemplate}, parses the given input, and
 	 * populates the template with the parsed values.
-	 *
+	 * <p>
+	 * See {@link #parseFromInto(Class, CLInput, Consumer)} for more info.
 	 * @param templateClass The class to use as a template.
 	 * @param input The input to parse.
 	 * @param <T> The type of the template.
 	 * @return The parsed template.
 	 * @see CommandTemplate
+	 * @see #parseFromInto(Class, CLInput, Consumer)
 	 */
 	public static <T extends CommandTemplate>
 	@NotNull T parseFromInto(@NotNull Class<T> templateClass, @NotNull CLInput input) {

--- a/src/main/java/lanat/ArgumentParser.java
+++ b/src/main/java/lanat/ArgumentParser.java
@@ -29,7 +29,7 @@ public class ArgumentParser extends Command {
 	private @Nullable String license;
 	private @Nullable String version;
 
-
+	// TODO: match constructor javadocs here with the ones in Command
 	/**
 	 * Creates a new command with the given name and description.
 	 * @param programName The name of the command. This is the name the user will use to indicate that they want to use this
@@ -59,6 +59,7 @@ public class ArgumentParser extends Command {
 		super(templateClass);
 	}
 
+	// TODO: add info about the code comparison between using from() and not using it
 	/**
 	 * Constructs a new {@link ArgumentParser} based on the given {@link CommandTemplate}, taking Sub-Commands into
 	 * account.

--- a/src/main/java/lanat/ArgumentType.java
+++ b/src/main/java/lanat/ArgumentType.java
@@ -287,7 +287,7 @@ public abstract class ArgumentType<T>
 
 	/**
 	 * Iterates over the values that this argument received when being parsed. This also sets
-	 * <code>this.currentArgValueIndex</code> to the current index of the value.
+	 * {@code this.currentArgValueIndex} to the current index of the value.
 	 *
 	 * @param args The values that this argument received when being parsed.
 	 * @param consumer The consumer that will be called for each value.

--- a/src/main/java/lanat/Command.java
+++ b/src/main/java/lanat/Command.java
@@ -184,10 +184,10 @@ public class Command
 	 * fail, the program will return the result of the OR bit operation that will be applied to all other command
 	 * results. For example:
 	 * <ul>
-	 *     <li>Command 'foo' has a return value of 2. <code>(0b010)</code></li>
-	 *     <li>Command 'bar' has a return value of 5. <code>(0b101)</code></li>
+	 *     <li>Command 'foo' has a return value of 2. {@code (0b010)}</li>
+	 *     <li>Command 'bar' has a return value of 5. {@code (0b101)}</li>
 	 * </ul>
-	 * Both commands failed, so in this case the resultant return value would be 7 <code>(0b111)</code>.
+	 * Both commands failed, so in this case the resultant return value would be 7 {@code (0b111)}.
 	 * @param errorCode The error code to return when this command fails.
 	 */
 	public void setErrorCode(int errorCode) {

--- a/src/main/java/lanat/Command.java
+++ b/src/main/java/lanat/Command.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  */
 public class Command
 	extends ErrorsContainerImpl<Error.CustomError>
-	implements ErrorCallbacks<ParsedArguments, Command>,
+	implements ErrorCallbacks<ParseResult, Command>,
 	ArgumentAdder,
 	ArgumentGroupAdder,
 	CommandAdder,
@@ -59,7 +59,7 @@ public class Command
 
 	// error handling callbacks
 	private @Nullable Consumer<Command> onErrorCallback;
-	private @Nullable Consumer<ParsedArguments> onCorrectCallback;
+	private @Nullable Consumer<ParseResult> onCorrectCallback;
 
 	private final @NotNull ModifyRecord<HelpFormatter> helpFormatter = ModifyRecord.of(new HelpFormatter());
 	private final @NotNull ModifyRecord<@NotNull CallbacksInvocationOption> callbackInvocationOption =
@@ -310,14 +310,14 @@ public class Command
 	}
 
 	/**
-	 * Returns a new {@link ParsedArguments} object that contains all the parsed arguments of this command and all its
+	 * Returns a new {@link ParseResult} object that contains all the parsed arguments of this command and all its
 	 * Sub-Commands.
 	 */
-	@NotNull ParsedArguments getParsedArguments() {
-		return new ParsedArguments(
+	@NotNull ParseResult getParseResult() {
+		return new ParseResult(
 			this,
-			this.parser.getParsedArgumentsHashMap(),
-			this.subCommands.stream().map(Command::getParsedArguments).toList()
+			this.parser.getParsedArgsMap(),
+			this.subCommands.stream().map(Command::getParseResult).toList()
 		);
 	}
 
@@ -480,19 +480,19 @@ public class Command
 	 * </p>
 	 */
 	@Override
-	public void setOnOkCallback(@Nullable Consumer<@NotNull ParsedArguments> callback) {
+	public void setOnOkCallback(@Nullable Consumer<@NotNull ParseResult> callback) {
 		this.onCorrectCallback = callback;
 	}
 
 	@Override
 	public void invokeCallbacks() {
 		if (this.shouldExecuteCorrectCallback()) {
-			if (this.onCorrectCallback != null) this.onCorrectCallback.accept(this.getParsedArguments());
+			if (this.onCorrectCallback != null) this.onCorrectCallback.accept(this.getParseResult());
 		} else {
 			if (this.onErrorCallback != null) this.onErrorCallback.accept(this);
 		}
 
-		this.parser.getParsedArgumentsHashMap()
+		this.parser.getParsedArgsMap()
 			.entrySet()
 			.stream()
 			.sorted((x, y) -> Argument.compareByPriority(x.getKey(), y.getKey())) // sort by priority when invoking callbacks!

--- a/src/main/java/lanat/Command.java
+++ b/src/main/java/lanat/Command.java
@@ -92,6 +92,7 @@ public class Command
 
 	/**
 	 * Creates a new command based on the given {@link CommandTemplate}. This does not take Sub-Commands into account.
+	 * If you want to add Sub-Commands, use {@link ArgumentParser#from(Class)} instead.
 	 * @param templateClass The class of the template to use.
 	 * @see CommandTemplate
 	 */

--- a/src/main/java/lanat/CommandTemplate.java
+++ b/src/main/java/lanat/CommandTemplate.java
@@ -101,31 +101,31 @@ import java.util.List;
 @Command.Define
 public abstract class CommandTemplate {
 	/** The parsed arguments of the command. */
-	private ParsedArguments parsedArguments;
+	private ParseResult parseResult;
 
 	/**
 	 * Called right after the Command Template is instantiated by the Argument Parser.
-	 * Sets the {@link #parsedArguments} field and calls {@link #onValuesReceived()} if the command was used.
+	 * Sets the {@link #parseResult} field and calls {@link #onValuesReceived()} if the command was used.
 	 * <p>
 	 * The reason this is used instead of a constructor is because we don't want to force inheritors to call
 	 * {@code super()} in their constructors. Also, this method is called first by the innermost Command in
 	 * the hierarchy, and then by the parent Commands.
-	 * @param parsedArguments The parsed arguments of the command.
+	 * @param parseResult The parsed arguments of the command.
 	 */
-	void afterInstantiation(@NotNull ParsedArguments parsedArguments) {
-		this.parsedArguments = parsedArguments;
+	void afterInstantiation(@NotNull ParseResult parseResult) {
+		this.parseResult = parseResult;
 		if (this.wasUsed()) this.onValuesReceived();
 	}
 
 	/**
-	 * Returns the {@link ParsedArguments} instance used by this Command Template. This instance is the one that was
+	 * Returns the {@link ParseResult} instance used by this Command Template. This instance is the one that was
 	 * used to initialize this Command Template.
-	 * @return The {@link ParsedArguments} instance used by this Command Template.
+	 * @return The {@link ParseResult} instance used by this Command Template.
 	 */
-	public final @NotNull ParsedArguments getParsedArguments() {
-		if (this.parsedArguments == null)
+	public final @NotNull ParseResult getParseResult() {
+		if (this.parseResult == null)
 			throw new IllegalStateException("Command Template was not properly initialized by the Argument Parser.");
-		return this.parsedArguments;
+		return this.parseResult;
 	}
 
 	/**
@@ -134,7 +134,7 @@ public abstract class CommandTemplate {
 	 * @return The {@link Command} instance used by this Command Template.
 	 */
 	public final @NotNull Command getCommand() {
-		return this.getParsedArguments().getCommand();
+		return this.getParseResult().getCommand();
 	}
 
 	/**
@@ -142,7 +142,7 @@ public abstract class CommandTemplate {
 	 * @return {@code true} if the Command of this Template was used in the command line, {@code false} otherwise.
 	 */
 	public final boolean wasUsed() {
-		return this.getParsedArguments().wasUsed();
+		return this.getParseResult().wasUsed();
 	}
 
 	/**

--- a/src/main/java/lanat/CommandTemplate.java
+++ b/src/main/java/lanat/CommandTemplate.java
@@ -145,12 +145,14 @@ public abstract class CommandTemplate {
 		return this.getParseResult().wasUsed();
 	}
 
-	// TODO: add note to not use this method manually
 	/**
 	 * Called when the Command of this Template is used in the command line.
 	 * This method is called after the parsed values are set.
 	 * <p>
 	 * This method may be overridden to perform actions when the command is used.
+	 * </p>
+	 * This method should not be called manually. It is called automatically by the Argument Parser once the Command
+	 * Template is initialized.
 	 */
 	public void onValuesReceived() {}
 

--- a/src/main/java/lanat/CommandTemplate.java
+++ b/src/main/java/lanat/CommandTemplate.java
@@ -145,6 +145,7 @@ public abstract class CommandTemplate {
 		return this.getParseResult().wasUsed();
 	}
 
+	// TODO: add note to not use this method manually
 	/**
 	 * Called when the Command of this Template is used in the command line.
 	 * This method is called after the parsed values are set.

--- a/src/main/java/lanat/CommandTemplate.java
+++ b/src/main/java/lanat/CommandTemplate.java
@@ -100,12 +100,16 @@ import java.util.List;
  */
 @Command.Define
 public abstract class CommandTemplate {
-	/**  */
+	/** The parsed arguments of the command. */
 	private ParsedArguments parsedArguments;
 
 	/**
 	 * Called right after the Command Template is instantiated by the Argument Parser.
 	 * Sets the {@link #parsedArguments} field and calls {@link #onValuesReceived()} if the command was used.
+	 * <p>
+	 * The reason this is used instead of a constructor is because we don't want to force inheritors to call
+	 * {@code super()} in their constructors. Also, this method is called first by the innermost Command in
+	 * the hierarchy, and then by the parent Commands.
 	 * @param parsedArguments The parsed arguments of the command.
 	 */
 	void afterInstantiation(@NotNull ParsedArguments parsedArguments) {

--- a/src/main/java/lanat/CommandTemplate.java
+++ b/src/main/java/lanat/CommandTemplate.java
@@ -100,6 +100,31 @@ import java.util.List;
  */
 @Command.Define
 public abstract class CommandTemplate {
+	private ParsedArguments parsedArguments;
+
+	/**
+	 *
+	 * @param parsedArguments
+	 */
+	void afterInstantiation(@NotNull ParsedArguments parsedArguments) {
+		this.parsedArguments = parsedArguments;
+		if (this.wasUsed()) this.onValuesReceived();
+	}
+
+	public final @NotNull ParsedArguments getParsedArguments() {
+		return this.parsedArguments;
+	}
+
+	public final @NotNull Command getCommand() {
+		return this.parsedArguments.getCommand();
+	}
+
+	public final boolean wasUsed() {
+		return this.parsedArguments.wasUsed();
+	}
+
+	public void onValuesReceived() {}
+
 	/**
 	 * Annotation used to define an init method for a Command Template.
 	 * @see CommandTemplate#beforeInit(CommandBuildHelper)

--- a/src/main/java/lanat/CommandTemplate.java
+++ b/src/main/java/lanat/CommandTemplate.java
@@ -100,30 +100,55 @@ import java.util.List;
  */
 @Command.Define
 public abstract class CommandTemplate {
+	/**  */
 	private ParsedArguments parsedArguments;
 
 	/**
-	 *
-	 * @param parsedArguments
+	 * Called right after the Command Template is instantiated by the Argument Parser.
+	 * Sets the {@link #parsedArguments} field and calls {@link #onValuesReceived()} if the command was used.
+	 * @param parsedArguments The parsed arguments of the command.
 	 */
 	void afterInstantiation(@NotNull ParsedArguments parsedArguments) {
 		this.parsedArguments = parsedArguments;
 		if (this.wasUsed()) this.onValuesReceived();
 	}
 
+	/**
+	 * Returns the {@link ParsedArguments} instance used by this Command Template. This instance is the one that was
+	 * used to initialize this Command Template.
+	 * @return The {@link ParsedArguments} instance used by this Command Template.
+	 */
 	public final @NotNull ParsedArguments getParsedArguments() {
+		if (this.parsedArguments == null)
+			throw new IllegalStateException("Command Template was not properly initialized by the Argument Parser.");
 		return this.parsedArguments;
 	}
 
+	/**
+	 * Returns the {@link Command} instance used by this Command Template. This instance is the one that was
+	 * used to initialize this Command Template.
+	 * @return The {@link Command} instance used by this Command Template.
+	 */
 	public final @NotNull Command getCommand() {
-		return this.parsedArguments.getCommand();
+		return this.getParsedArguments().getCommand();
 	}
 
+	/**
+	 * Returns {@code true} if the Command of this Template was used in the command line.
+	 * @return {@code true} if the Command of this Template was used in the command line, {@code false} otherwise.
+	 */
 	public final boolean wasUsed() {
-		return this.parsedArguments.wasUsed();
+		return this.getParsedArguments().wasUsed();
 	}
 
+	/**
+	 * Called when the Command of this Template is used in the command line.
+	 * This method is called after the parsed values are set.
+	 * <p>
+	 * This method may be overridden to perform actions when the command is used.
+	 */
 	public void onValuesReceived() {}
+
 
 	/**
 	 * Annotation used to define an init method for a Command Template.

--- a/src/main/java/lanat/ParseResult.java
+++ b/src/main/java/lanat/ParseResult.java
@@ -73,10 +73,9 @@ public class ParseResult {
 		return Optional.ofNullable((T)this.parsedArgumentValues.get(arg));
 	}
 
-	// TODO: replace all <code>...</code> instances with {@code ...}
 	/**
 	 * Returns the parsed value of the argument with the given name. In order to access arguments in sub-commands, use
-	 * the <code>.</code> separator to specify the route to the argument.
+	 * the {@code .} separator to specify the route to the argument.
 	 *
 	 * <br><br>
 	 *
@@ -87,7 +86,7 @@ public class ParseResult {
 	 * <p>
 	 * More info at {@link #get(String...)}
 	 *
-	 * @param argRoute The route to the argument, separated by the <code>.</code> character.
+	 * @param argRoute The route to the argument, separated by the {@code .} character.
 	 * @param <T> The type of the value of the argument. This is used to avoid casting. A type that does not match the
 	 * 	argument's type will result in a {@link ClassCastException}.
 	 * @return An {@link Optional} containing the parsed value of the argument with the given name, or

--- a/src/main/java/lanat/ParseResult.java
+++ b/src/main/java/lanat/ParseResult.java
@@ -25,7 +25,7 @@ public class ParseResult {
 	private final boolean wasUsed;
 
 	/** The other inner {@link ParseResult}s for the sub-commands */
-	private final @NotNull List<@NotNull ParseResult> subResults;
+	protected final @NotNull List<@NotNull ParseResult> subResults;
 
 
 	ParseResult(
@@ -73,6 +73,7 @@ public class ParseResult {
 		return Optional.ofNullable((T)this.parsedArgumentValues.get(arg));
 	}
 
+	// TODO: replace all <code>...</code> instances with {@code ...}
 	/**
 	 * Returns the parsed value of the argument with the given name. In order to access arguments in sub-commands, use
 	 * the <code>.</code> separator to specify the route to the argument.
@@ -95,6 +96,9 @@ public class ParseResult {
 	 * @throws ArgumentNotFoundException If the argument specified in the route does not exist
 	 */
 	public <T> @NotNull Optional<T> get(@NotNull String argRoute) {
+		if (!argRoute.contains("."))
+			return this.get(new String[] { argRoute });
+
 		return this.get(UtlString.split(argRoute, '.'));
 	}
 
@@ -120,6 +124,7 @@ public class ParseResult {
 	 * </ul>
 	 *
 	 * @throws CommandNotFoundException If the command specified in the route does not exist
+	 * @throws ArgumentNotFoundException If the argument specified in the route does not exist
 	 * @return An {@link Optional} containing the parsed value of the argument with the given name, or
 	 *  {@link Optional#empty()} if the argument was not found.
 	 * @param <T> The type of the value of the argument.

--- a/src/main/java/lanat/ParseResult.java
+++ b/src/main/java/lanat/ParseResult.java
@@ -14,29 +14,29 @@ import java.util.Optional;
 /**
  * Container for all the parsed arguments and their respective values.
  */
-public class ParsedArguments {
+public class ParseResult {
 	/** The parsed arguments. Pairs of each argument and it's respective value */
-	private final @NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgs;
+	private final @NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgumentValues;
 
-	/** The {@link Command} that this {@link ParsedArguments} object belongs to */
+	/** The {@link Command} that this {@link ParseResult} object belongs to */
 	private final @NotNull Command cmd;
 
 	/** Whether the command was used or not */
 	private final boolean wasUsed;
 
-	/** The other inner {@link ParsedArguments}s for the sub-commands */
-	private final @NotNull List<@NotNull ParsedArguments> subParsedArguments;
+	/** The other inner {@link ParseResult}s for the sub-commands */
+	private final @NotNull List<@NotNull ParseResult> subResults;
 
 
-	ParsedArguments(
+	ParseResult(
 		@NotNull Command cmd,
-		@NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgs,
-		@NotNull List<@NotNull ParsedArguments> subParsedArguments
+		@NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgumentValues,
+		@NotNull List<@NotNull ParseResult> subResults
 	) {
-		this.parsedArgs = parsedArgs;
+		this.parsedArgumentValues = parsedArgumentValues;
 		this.cmd = cmd;
 		this.wasUsed = cmd.getTokenizer().hasFinished();
-		this.subParsedArguments = subParsedArguments;
+		this.subResults = subResults;
 	}
 
 
@@ -49,9 +49,9 @@ public class ParsedArguments {
 	}
 
 	/**
-	 * Returns the {@link Command} that this {@link ParsedArguments} object belongs to. This is the Command
+	 * Returns the {@link Command} that this {@link ParseResult} object belongs to. This is the Command
 	 * that was used to parse the arguments.
-	 * @return The {@link Command} that this {@link ParsedArguments} object belongs to
+	 * @return The {@link Command} that this {@link ParseResult} object belongs to
 	 */
 	public @NotNull Command getCommand() {
 		return this.cmd;
@@ -66,11 +66,11 @@ public class ParsedArguments {
 	 */
 	@SuppressWarnings("unchecked") // we'll just have to trust the user
 	public <T> @NotNull Optional<T> get(@NotNull Argument<?, T> arg) {
-		if (!this.parsedArgs.containsKey(arg)) {
+		if (!this.parsedArgumentValues.containsKey(arg)) {
 			throw new ArgumentNotFoundException(arg);
 		}
 
-		return Optional.ofNullable((T)this.parsedArgs.get(arg));
+		return Optional.ofNullable((T)this.parsedArgumentValues.get(arg));
 	}
 
 	/**
@@ -81,7 +81,7 @@ public class ParsedArguments {
 	 *
 	 * <strong>Example:</strong>
 	 * <pre>
-	 * {@code var argValue = parsedArguments.<String>get("rootcommand.subCommand.argument")}
+	 * {@code var argValue = result.<String>get("rootcommand.subCommand.argument")}
 	 * </pre>
 	 * <p>
 	 * More info at {@link #get(String...)}
@@ -106,7 +106,7 @@ public class ParsedArguments {
 	 *
 	 * <strong>Example:</strong>
 	 * <pre>
-	 * {@code var argValue = parsedArguments.<String>get("rootcommand", "subCommand", "argument")}
+	 * {@code var argValue = result.<String>get("rootcommand", "subCommand", "argument")}
 	 * </pre>
 	 * Returns the parsed value of the argument in the next command hierarchy:
 	 * <ul>
@@ -134,16 +134,16 @@ public class ParsedArguments {
 			return (Optional<T>)this.get(this.getArgument(argRoute[0]));
 		}
 
-		return this.getSubParsedArgs(argRoute[0])
+		return this.getSubResult(argRoute[0])
 			.get(Arrays.copyOfRange(argRoute, 1, argRoute.length));
 	}
 
 	/**
-	 * Returns the argument in {@link #parsedArgs} with the given name.
+	 * Returns the argument in {@link #parsedArgumentValues} with the given name.
 	 * @throws ArgumentNotFoundException If no argument with the given name is found
 	 */
 	private @NotNull Argument<?, ?> getArgument(@NotNull String name) {
-		for (var arg : this.parsedArgs.keySet()) {
+		for (var arg : this.parsedArgumentValues.keySet()) {
 			if (arg.hasName(name)) {
 				return arg;
 			}
@@ -151,16 +151,17 @@ public class ParsedArguments {
 		throw new ArgumentNotFoundException(name);
 	}
 
+	// TODO: FIX DESCRIPTION
 	/**
-	 * Returns the sub {@link ParsedArguments} with the given name. If none is found with the given name, returns
+	 * Returns the sub {@link ParseResult} with the given name. If none is found with the given name, returns
 	 * {@code null}.
 	 *
 	 * @param name The name of the sub command
 	 * @throws CommandNotFoundException If no sub command with the given name is found
-	 * @return The sub {@link ParsedArguments} with the given name
+	 * @return The sub {@link ParseResult} with the given name
 	 */
-	public @NotNull ParsedArguments getSubParsedArgs(@NotNull String name) {
-		for (var sub : this.subParsedArguments)
+	public @NotNull ParseResult getSubResult(@NotNull String name) {
+		for (var sub : this.subResults)
 			if (sub.cmd.hasName(name)) return sub;
 
 		throw new CommandNotFoundException(name);

--- a/src/main/java/lanat/ParseResult.java
+++ b/src/main/java/lanat/ParseResult.java
@@ -156,10 +156,9 @@ public class ParseResult {
 		throw new ArgumentNotFoundException(name);
 	}
 
-	// TODO: FIX DESCRIPTION
 	/**
-	 * Returns the sub {@link ParseResult} with the given name. If none is found with the given name, returns
-	 * {@code null}.
+	 * Returns the sub {@link ParseResult} with the given name. If none is found with the given name,
+	 * {@link CommandNotFoundException} is thrown.
 	 *
 	 * @param name The name of the sub command
 	 * @throws CommandNotFoundException If no sub command with the given name is found

--- a/src/main/java/lanat/ParseResultRoot.java
+++ b/src/main/java/lanat/ParseResultRoot.java
@@ -3,6 +3,7 @@ package lanat;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -32,5 +33,31 @@ public class ParseResultRoot extends ParseResult {
 	 */
 	public @NotNull Optional<String> getForwardValue() {
 		return Optional.ofNullable(this.forwardValue);
+	}
+
+	/**
+	 * Returns a list of all the {@link ParseResult} objects that belong to a command that was used by the user.
+	 * The list is ordered from the root command to the last used command.
+	 * <p>
+	 * The list contains this {@link ParseResultRoot} object as well.
+	 * @return A list of all the {@link ParseResult} objects that belong to a command that was used by the user
+	 */
+	public @NotNull List<@NotNull ParseResult> getUsedResults() {
+		if (!this.wasUsed())
+			return List.of();
+
+		ParseResult current = this;
+		var list = new ArrayList<ParseResult>(1);
+
+		while (current != null) {
+			list.add(current);
+
+			current = current.subResults.stream()
+				.filter(ParseResult::wasUsed)
+				.findFirst()
+				.orElse(null);
+		}
+
+		return list;
 	}
 }

--- a/src/main/java/lanat/ParseResultRoot.java
+++ b/src/main/java/lanat/ParseResultRoot.java
@@ -11,17 +11,17 @@ import java.util.Optional;
  * Container for all the parsed arguments and their respective values.
  * Provides methods specific to the root command.
  */
-public class ParsedArgumentsRoot extends ParsedArguments {
+public class ParseResultRoot extends ParseResult {
 	private final @Nullable String forwardValue;
 
-	ParsedArgumentsRoot(
+	ParseResultRoot(
 		@NotNull ArgumentParser cmd,
-		@NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgs,
-		@NotNull List<@NotNull ParsedArguments> subArgs,
+		@NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgumentValues,
+		@NotNull List<@NotNull ParseResult> subArgs,
 		@Nullable String forwardValue
 	)
 	{
-		super(cmd, parsedArgs, subArgs);
+		super(cmd, parsedArgumentValues, subArgs);
 		this.forwardValue = forwardValue;
 	}
 

--- a/src/main/java/lanat/ParseResultRoot.java
+++ b/src/main/java/lanat/ParseResultRoot.java
@@ -20,8 +20,7 @@ public class ParseResultRoot extends ParseResult {
 		@NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgumentValues,
 		@NotNull List<@NotNull ParseResult> subArgs,
 		@Nullable String forwardValue
-	)
-	{
+	) {
 		super(cmd, parsedArgumentValues, subArgs);
 		this.forwardValue = forwardValue;
 	}

--- a/src/main/java/lanat/ParsedArguments.java
+++ b/src/main/java/lanat/ParsedArguments.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 public class ParsedArguments {
 	private final @NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgs;
 	private final @NotNull Command cmd;
+	private final boolean wasUsed;
 	private final @NotNull List<@NotNull ParsedArguments> subParsedArguments;
 
 	ParsedArguments(
@@ -27,7 +28,16 @@ public class ParsedArguments {
 	{
 		this.parsedArgs = parsedArgs;
 		this.cmd = cmd;
+		this.wasUsed = cmd.getTokenizer().hasFinished();
 		this.subParsedArguments = subParsedArguments;
+	}
+
+	public boolean wasUsed() {
+		return this.wasUsed;
+	}
+
+	public @NotNull Command getCommand() {
+		return this.cmd;
 	}
 
 	/**

--- a/src/main/java/lanat/ParsedArguments.java
+++ b/src/main/java/lanat/ParsedArguments.java
@@ -113,20 +113,16 @@ public class ParsedArguments {
 			throw new IllegalArgumentException("argument route must not be empty");
 		}
 
-		ParsedArguments matchedParsedArgs;
-
 		if (argRoute.length == 1) {
 			return (Optional<T>)this.get(this.getArgument(argRoute[0]));
-		} else if ((matchedParsedArgs = this.getSubParsedArgs(argRoute[0])) != null) {
-			return matchedParsedArgs.get(Arrays.copyOfRange(argRoute, 1, argRoute.length));
-		} else {
-			throw new CommandNotFoundException(argRoute[0]);
 		}
+
+		return this.getSubParsedArgs(argRoute[0])
+			.get(Arrays.copyOfRange(argRoute, 1, argRoute.length));
 	}
 
 	/**
 	 * Returns the argument in {@link #parsedArgs} with the given name.
-	 *
 	 * @throws ArgumentNotFoundException If no argument with the given name is found
 	 */
 	private @NotNull Argument<?, ?> getArgument(@NotNull String name) {
@@ -143,11 +139,13 @@ public class ParsedArguments {
 	 * {@code null}.
 	 *
 	 * @param name The name of the sub command
+	 * @throws CommandNotFoundException If no sub command with the given name is found
 	 * @return The sub {@link ParsedArguments} with the given name, or {@code null} if none is found
 	 */
-	public ParsedArguments getSubParsedArgs(@NotNull String name) {
+	public @NotNull ParsedArguments getSubParsedArgs(@NotNull String name) {
 		for (var sub : this.subParsedArguments)
 			if (sub.cmd.hasName(name)) return sub;
-		return null;
+
+		throw new CommandNotFoundException(name);
 	}
 }

--- a/src/main/java/lanat/ParsedArguments.java
+++ b/src/main/java/lanat/ParsedArguments.java
@@ -15,22 +15,30 @@ import java.util.Optional;
  * Container for all the parsed arguments and their respective values.
  */
 public class ParsedArguments {
+	/** The parsed arguments. Pairs of each argument and it's respective value */
 	private final @NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgs;
+
+	/** The {@link Command} that this {@link ParsedArguments} object belongs to */
 	private final @NotNull Command cmd;
+
+	/** Whether the command was used or not */
 	private final boolean wasUsed;
+
+	/** The other inner {@link ParsedArguments}s for the sub-commands */
 	private final @NotNull List<@NotNull ParsedArguments> subParsedArguments;
+
 
 	ParsedArguments(
 		@NotNull Command cmd,
 		@NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgs,
 		@NotNull List<@NotNull ParsedArguments> subParsedArguments
-	)
-	{
+	) {
 		this.parsedArgs = parsedArgs;
 		this.cmd = cmd;
 		this.wasUsed = cmd.getTokenizer().hasFinished();
 		this.subParsedArguments = subParsedArguments;
 	}
+
 
 	/**
 	 * Returns {@code true} if the command was used, {@code false} otherwise.

--- a/src/main/java/lanat/ParsedArguments.java
+++ b/src/main/java/lanat/ParsedArguments.java
@@ -32,10 +32,19 @@ public class ParsedArguments {
 		this.subParsedArguments = subParsedArguments;
 	}
 
+	/**
+	 * Returns {@code true} if the command was used, {@code false} otherwise.
+	 * @return {@code true} if the command was used, {@code false} otherwise
+	 */
 	public boolean wasUsed() {
 		return this.wasUsed;
 	}
 
+	/**
+	 * Returns the {@link Command} that this {@link ParsedArguments} object belongs to. This is the Command
+	 * that was used to parse the arguments.
+	 * @return The {@link Command} that this {@link ParsedArguments} object belongs to
+	 */
 	public @NotNull Command getCommand() {
 		return this.cmd;
 	}
@@ -140,7 +149,7 @@ public class ParsedArguments {
 	 *
 	 * @param name The name of the sub command
 	 * @throws CommandNotFoundException If no sub command with the given name is found
-	 * @return The sub {@link ParsedArguments} with the given name, or {@code null} if none is found
+	 * @return The sub {@link ParsedArguments} with the given name
 	 */
 	public @NotNull ParsedArguments getSubParsedArgs(@NotNull String name) {
 		for (var sub : this.subParsedArguments)

--- a/src/main/java/lanat/argumentTypes/TupleArgumentType.java
+++ b/src/main/java/lanat/argumentTypes/TupleArgumentType.java
@@ -52,7 +52,7 @@ public abstract class TupleArgumentType<T> extends ArgumentType<T[]> {
 			return null;
 
 		return argTypeRepr
-			.concat(new TextFormatter(this.argCount.getRegexRange()).withForegroundColor(Color.BRIGHT_YELLOW));
+			.concat(new TextFormatter(this.argCount.getRepresentation()).withForegroundColor(Color.BRIGHT_YELLOW));
 	}
 
 	@Override

--- a/src/main/java/lanat/helpRepresentation/descriptions/RouteParser.java
+++ b/src/main/java/lanat/helpRepresentation/descriptions/RouteParser.java
@@ -69,7 +69,7 @@ public class RouteParser {
 
 	private RouteParser(@NotNull NamedWithDescription user, @Nullable String route) {
 		// if route is empty, the command the user belongs to is the target
-		if (UtlString.isNullOrEmpty(route)) { // TODO: replace with UtlString.isNullOrBlank once utils is bumped
+		if (UtlString.isNullOrBlank(route)) {
 			this.currentTarget = RouteParser.getCommandOf(user);
 			this.route = new String[0];
 			return;

--- a/src/main/java/lanat/helpRepresentation/descriptions/RouteParser.java
+++ b/src/main/java/lanat/helpRepresentation/descriptions/RouteParser.java
@@ -13,28 +13,28 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 /**
- * Parser for simple route syntax used in description tags (e.g. <code>args.myArg1.type</code>).
+ * Parser for simple route syntax used in description tags (e.g. {@code args.myArg1.type}).
  * <p>
  * The route syntax is very simple. It is a dot-separated list of names indicating the path to the object to be
  * returned. By default, the route initial target is the command the user belongs to. If the route starts with
- * <code>!</code>, the user itself becomes the initial target. If the route is empty or null, the command the user
+ * {@code !}, the user itself becomes the initial target. If the route is empty or null, the command the user
  * belongs to is returned.
  * </p>
  * <p>
  * These are the objects that can be accessed using the route syntax:
  * <ul>
- * <li><code>args</code>: the arguments of the command.
+ * <li>{@code args}: the arguments of the command.
  * <ul>
- * <li><code>type</code>: the type of the argument.
+ * <li>{@code type}: the type of the argument.
  * <p>
  * Note that this only works if the current target is an {@link Argument}.
  * </p>
  * </li>
  * </ul>
  * </li>
- * <li><code>groups</code>: the groups of the command.</li>
+ * <li>{@code groups}: the groups of the command.</li>
  * <li>
- * <code>cmds</code>: the subcommands of the command.
+ * {@code cmds}: the subcommands of the command.
  * <p>
  * Note that after selecting a command, all the selectors above can be used again to select inner objects of the command.
  * </p>
@@ -44,20 +44,20 @@ import java.util.function.BiFunction;
  * <h2>Examples</h2>
  * <ol>
  * <li>
- * Select the type of the argument <code>myArg1</code> of the current command:
- * <code>"args.myArg1.type"</code>
+ * Select the type of the argument {@code myArg1} of the current command:
+ * {@code "args.myArg1.type"}
  * </li>
  * <li>
- * Select the Sub-Command <code>myCmd</code> of the current command:
- * <code>"cmds.myCmd"</code>
+ * Select the Sub-Command {@code myCmd} of the current command:
+ * {@code "cmds.myCmd"}
  * </li>
  * <li>
- * Select the type of the argument <code>myArg1</code> of the Sub-Command <code>myCmd</code> of the current command:
- * <code>"cmds.myCmd.args.myArg1.type"</code>
+ * Select the type of the argument {@code myArg1} of the Sub-Command {@code myCmd} of the current command:
+ * {@code "cmds.myCmd.args.myArg1.type"}
  * </li>
  * <li>
  * Select the {@link ArgumentType} of the {@link Argument} that is requesting to parse this description:
- * <code>"!.type"</code>
+ * {@code "!.type"}
  * </li>
  * </ol>
  */
@@ -94,7 +94,7 @@ public class RouteParser {
 	 * to is returned.
 	 * <p>
 	 * The reason why the user is needed is because its likely that it will be needed to gather the Command it belongs
-	 * to, and also if the route starts with <code>!</code>, the user itself becomes the initial target.
+	 * to, and also if the route starts with {@code !}, the user itself becomes the initial target.
 	 * </p>
 	 *
 	 * @param user the user that is requesting to parse the route

--- a/src/main/java/lanat/helpRepresentation/descriptions/RouteParser.java
+++ b/src/main/java/lanat/helpRepresentation/descriptions/RouteParser.java
@@ -69,7 +69,7 @@ public class RouteParser {
 
 	private RouteParser(@NotNull NamedWithDescription user, @Nullable String route) {
 		// if route is empty, the command the user belongs to is the target
-		if (UtlString.isNullOrEmpty(route)) {
+		if (UtlString.isNullOrEmpty(route)) { // TODO: replace with UtlString.isNullOrBlank once utils is bumped
 			this.currentTarget = RouteParser.getCommandOf(user);
 			this.route = new String[0];
 			return;

--- a/src/main/java/lanat/parsing/Parser.java
+++ b/src/main/java/lanat/parsing/Parser.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
  * of the arguments that are being parsed.
  * </p>
  * When finished parsing, this class will contain a map of the arguments to their parsed values. This map can be accessed
- * by calling {@link Parser#getParsedArgumentsHashMap()}.
+ * by calling {@link Parser#getParsedArgsMap()}.
  */
 public final class Parser extends ParsingStateBase<Error.ParseError> {
 	/**
@@ -41,10 +41,10 @@ public final class Parser extends ParsingStateBase<Error.ParseError> {
 
 	/**
 	 * The parsed arguments. This is a map of the argument to the value that it parsed. The reason this is saved is that
-	 * we don't want to run {@link Parser#getParsedArgumentsHashMap()} multiple times because that can break stuff badly
+	 * we don't want to run {@link Parser#getParsedArgsMap()} multiple times because that can break stuff badly
 	 * in relation to error handling.
 	 */
-	private HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArguments;
+	private HashMap<@NotNull Argument<?, ?>, @Nullable Object> parsedArgumentValues;
 
 	/** Contains the forward value if one was found. */
 	private @Nullable String forwardValue;
@@ -316,13 +316,13 @@ public final class Parser extends ParsingStateBase<Error.ParseError> {
 	 * This function invokes the {@link Argument#finishParsing()} method on each argument the first time it is called.
 	 * After that, it will return the same hashmap.
 	 * */
-	public @NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> getParsedArgumentsHashMap() {
-		if (this.parsedArguments == null) {
-			this.parsedArguments = new HashMap<>() {{
+	public @NotNull HashMap<@NotNull Argument<?, ?>, @Nullable Object> getParsedArgsMap() {
+		if (this.parsedArgumentValues == null) {
+			this.parsedArgumentValues = new HashMap<>() {{
 				Parser.this.command.getArguments().forEach(arg -> this.put(arg, arg.finishParsing()));
 			}};
 		}
-		return this.parsedArguments;
+		return this.parsedArgumentValues;
 	}
 
 	private void argumentTypeParseValues(@NotNull Argument<?, ?> argument, @NotNull String... values) {

--- a/src/main/java/lanat/parsing/Tokenizer.java
+++ b/src/main/java/lanat/parsing/Tokenizer.java
@@ -268,7 +268,7 @@ public final class Tokenizer extends ParsingStateBase<Error.TokenizeError> {
 	}
 
 	/**
-	 * Returns {@code true} if the given string can be an argument name list, eg: <code>"-fbq"</code>.
+	 * Returns {@code true} if the given string can be an argument name list, eg: {@code "-fbq"}.
 	 * <p>
 	 * This returns {@code true} if at least the first character is a valid argument prefix and at least one of the
 	 * next characters is a valid argument name.
@@ -300,7 +300,7 @@ public final class Tokenizer extends ParsingStateBase<Error.TokenizeError> {
 	}
 
 	/**
-	 * Returns {@code true} if the given string can be an argument name, eg: <code>"--help"</code>.
+	 * Returns {@code true} if the given string can be an argument name, eg: {@code "--help"}.
 	 * <p>
 	 * This returns {@code true} if the given string is a valid argument name with a double prefix.
 	 * </p>

--- a/src/test/java/lanat/test/TestingParser.java
+++ b/src/test/java/lanat/test/TestingParser.java
@@ -3,7 +3,7 @@ package lanat.test;
 import lanat.ArgumentParser;
 import lanat.CLInput;
 import lanat.CommandTemplate;
-import lanat.ParsedArgumentsRoot;
+import lanat.ParseResultRoot;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -27,8 +27,8 @@ public class TestingParser extends ArgumentParser {
 		return this.parse(CLInput.from(args)).getErrors();
 	}
 
-	public @NotNull ParsedArgumentsRoot parseGetValues(@NotNull String args) {
-		var res = this.parse(CLInput.from(args)).printErrors().getParsedArguments();
+	public @NotNull ParseResultRoot parseGetValues(@NotNull String args) {
+		var res = this.parse(CLInput.from(args)).printErrors().getResult();
 		assertNotNull(res, "The result of the parsing was null (Arguments have failed)");
 		return res;
 	}

--- a/src/test/java/lanat/test/exampleTests/CommandTemplateExample.java
+++ b/src/test/java/lanat/test/exampleTests/CommandTemplateExample.java
@@ -60,6 +60,7 @@ public class CommandTemplateExample extends CommandTemplate.Default {
 
 	@InitDef
 	public static void afterInit(@NotNull Command cmd) {
+		cmd.setOnOkCallback(p -> System.out.println("ok " + cmd.getName()));
 		cmd.addGroup(new ArgumentGroup("test-group") {{
 			this.setRestricted(true);
 			this.addArgument(cmd.getArgument("string"));
@@ -75,13 +76,21 @@ public class CommandTemplateExample extends CommandTemplate.Default {
 		@Argument.Define(argType = CounterArgumentType.class, description = "This is a counter", names = "c")
 		public int counter = 0;
 
+		@InitDef
+		public static void afterInit(@NotNull Command cmd) {
+			cmd.setOnOkCallback(p -> System.out.println("ok " + cmd.getName()));
+		}
+
 		@CommandAccessor
 		public AnotherSubCommand anotherSubCommand;
 
 		@Command.Define(names = "another-sub-command", description = "This is a sub-command.")
 		public static class AnotherSubCommand extends CommandTemplate {
 			public AnotherSubCommand() {}
-
+			@InitDef
+			public static void afterInit(@NotNull Command cmd) {
+				cmd.setOnOkCallback(p -> System.out.println("ok " + cmd.getName()));
+			}
 			@Argument.Define(argType = CounterArgumentType.class, description = "This is a counter", names = "c")
 			public int counter = 0;
 		}

--- a/src/test/java/lanat/test/exampleTests/CommandTemplateExample.java
+++ b/src/test/java/lanat/test/exampleTests/CommandTemplateExample.java
@@ -1,9 +1,6 @@
 package lanat.test.exampleTests;
 
-import lanat.Argument;
-import lanat.ArgumentGroup;
-import lanat.Command;
-import lanat.CommandTemplate;
+import lanat.*;
 import lanat.argumentTypes.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,8 +9,6 @@ import java.util.Optional;
 
 @Command.Define(names = "my-program", description = "This is a <color=cyan><format=b,i>test program<format=reset>.")
 public class CommandTemplateExample extends CommandTemplate.Default {
-	public CommandTemplateExample() {}
-
 	@Argument.Define(argType = StringArgumentType.class, description = "This is a string argument.")
 	public Optional<String> string;
 
@@ -60,7 +55,6 @@ public class CommandTemplateExample extends CommandTemplate.Default {
 
 	@InitDef
 	public static void afterInit(@NotNull Command cmd) {
-		cmd.setOnOkCallback(p -> System.out.println("ok " + cmd.getName()));
 		cmd.addGroup(new ArgumentGroup("test-group") {{
 			this.setRestricted(true);
 			this.addArgument(cmd.getArgument("string"));
@@ -68,31 +62,34 @@ public class CommandTemplateExample extends CommandTemplate.Default {
 		}});
 	}
 
+	@Override
+	public void onValuesReceived() {
+		System.out.println("This is the value of number: " + this.number);
+	}
 
 	@Command.Define(names = "sub-command", description = "This is a sub-command.")
 	public static class MySubCommand extends CommandTemplate.Default {
-		public MySubCommand() {}
 
 		@Argument.Define(argType = CounterArgumentType.class, description = "This is a counter", names = "c")
 		public int counter = 0;
 
-		@InitDef
-		public static void afterInit(@NotNull Command cmd) {
-			cmd.setOnOkCallback(p -> System.out.println("ok " + cmd.getName()));
-		}
-
 		@CommandAccessor
 		public AnotherSubCommand anotherSubCommand;
 
+		@Override
+		public void onValuesReceived() {
+			System.out.println("This is the value of counter: " + this.counter);
+		}
+
 		@Command.Define(names = "another-sub-command", description = "This is a sub-command.")
 		public static class AnotherSubCommand extends CommandTemplate {
-			public AnotherSubCommand() {}
-			@InitDef
-			public static void afterInit(@NotNull Command cmd) {
-				cmd.setOnOkCallback(p -> System.out.println("ok " + cmd.getName()));
-			}
 			@Argument.Define(argType = CounterArgumentType.class, description = "This is a counter", names = "c")
 			public int counter = 0;
+
+			@Override
+			public void onValuesReceived() {
+				System.out.println("This is the value of counter: " + this.counter);
+			}
 		}
 	}
 }

--- a/src/test/java/lanat/test/exampleTests/ExampleTest.java
+++ b/src/test/java/lanat/test/exampleTests/ExampleTest.java
@@ -1,10 +1,6 @@
 package lanat.test.exampleTests;
 
 import lanat.*;
-import lanat.argumentTypes.CounterArgumentType;
-import lanat.argumentTypes.IntegerArgumentType;
-import lanat.argumentTypes.MultipleStringsArgumentType;
-import lanat.argumentTypes.NumberRangeArgumentType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -18,11 +14,26 @@ public final class ExampleTest {
 //		TextFormatter.enableSequences = false;
 //		ErrorFormatter.errorFormatterClass = SimpleErrorFormatter.class;
 
-		var result = ArgumentParser.parseFromInto(
-			CommandTemplateExample.class,
-			CLInput.from("--number 12 sub-command -ccc"),
-			opts -> opts.printErrors()
-		);
+//		ArgumentParser.parseFromInto(
+//			CommandTemplateExample.class,
+//			CLInput.from("--number 12 sub-command -ccc"),
+//			opts -> opts.printErrors()
+//		);
+
+		ArgumentParser.from(CommandTemplateExample.class)
+			.parse(CLInput.from("--number 12 sub-command -ccc"))
+			.getResult()
+			.getUsedResults()
+			.forEach(result -> {
+				var cmdName = result.getCommand().getName();
+				System.out.println(cmdName + " was used!");
+
+				switch (cmdName) {
+					case "my-program" -> System.out.println("number value: " + result.get("number"));
+					case "sub-command" -> System.out.println("c value: " + result.get("c"));
+					case "another-sub-command" -> System.out.println("c value: " + result.get("c"));
+				}
+			});
 	}
 
 	public static class Example1Type extends ArgumentType<String[]> {

--- a/src/test/java/lanat/test/exampleTests/ExampleTest.java
+++ b/src/test/java/lanat/test/exampleTests/ExampleTest.java
@@ -18,32 +18,11 @@ public final class ExampleTest {
 //		TextFormatter.enableSequences = false;
 //		ErrorFormatter.errorFormatterClass = SimpleErrorFormatter.class;
 
-		var ap = new ArgumentParser("my-program") {{
-			this.setCallbackInvocationOption(CallbacksInvocationOption.NO_ERROR_IN_ARGUMENT);
-			this.setDescription("This is the description of my program. What do you think about it? Oh by the way, don't forget to use the <link=args.user> argument!");
-			this.setLicense("Here's some more extra information about my program. Really don't know how to fill this out...");
-			this.addHelpArgument();
-			this.addArgument(Argument.create(new CounterArgumentType(), "counter", "c").onOk(System.out::println));
-			this.addArgument(Argument.create(new Example1Type(), "user", "u").required().positional().withDescription("Specify the user/s to use."));
-			this.addArgument(Argument.createOfBoolType("t").onOk(v -> System.out.println("present")));
-			this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println).withDescription("The value that matters the most (not really). Hey, this thing is generated automatically as well!: <desc=!.type>"));
-			this.addArgument(Argument.create(new MultipleStringsArgumentType(Range.from(3).to(5)), "string", "s").onOk(System.out::println).withPrefix(Argument.PrefixChar.PLUS));
-			this.addArgument(Argument.create(new IntegerArgumentType(), "test").onOk(System.out::println).allowsUnique());
-
-			this.addCommand(new Command("sub1", "testing") {{
-				this.addArgument(Argument.create(new IntegerArgumentType(), "required").required().positional());
-				this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println));
-				this.setDescription("Now this is the description of the subcommand inside the main command.");
-				this.addCommand(new Command("sub2", "testing") {{
-					this.addArgument(Argument.create(new IntegerArgumentType(), "required").required().positional());
-					this.addArgument(Argument.create(new NumberRangeArgumentType<>(0.0, 15.23), "number").onOk(System.out::println));
-				}});
-			}});
-		}};
-
-		ap.parse(CLInput.from("josh ! --number 2 sub1 --required 1 --number 121"))
-			.printErrors()
-			.getParsedArguments();
+		var result = ArgumentParser.parseFromInto(
+			CommandTemplateExample.class,
+			CLInput.from("--number 12 sub-command -ccc"),
+			opts -> opts.printErrors()
+		);
 	}
 
 	public static class Example1Type extends ArgumentType<String[]> {

--- a/src/test/java/lanat/test/units/TestParsedValues.java
+++ b/src/test/java/lanat/test/units/TestParsedValues.java
@@ -1,6 +1,6 @@
 package lanat.test.units;
 
-import lanat.ParsedArgumentsRoot;
+import lanat.ParseResultRoot;
 import lanat.exceptions.ArgumentNotFoundException;
 import lanat.test.UnitTests;
 import org.junit.jupiter.api.DisplayName;
@@ -11,7 +11,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestParsedValues extends UnitTests {
-	private ParsedArgumentsRoot parseArgs(String args) {
+	private ParseResultRoot parseArgs(String args) {
 		return this.parser.parseGetValues(args);
 	}
 

--- a/src/test/java/lanat/test/units/commandTemplates/CmdTemplates.java
+++ b/src/test/java/lanat/test/units/commandTemplates/CmdTemplates.java
@@ -3,12 +3,10 @@ package lanat.test.units.commandTemplates;
 import lanat.Argument;
 import lanat.Command;
 import lanat.CommandTemplate;
-import lanat.ParsedArguments;
 import lanat.argumentTypes.BooleanArgumentType;
 import lanat.argumentTypes.FloatArgumentType;
 import lanat.argumentTypes.IntegerArgumentType;
 import lanat.argumentTypes.StringArgumentType;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 
@@ -31,7 +29,6 @@ public class CmdTemplates {
 		@CommandAccessor
 		public CmdTemplate1_1 cmd2;
 
-
 		@Command.Define(names = "cmd1-1")
 		public static class CmdTemplate1_1 extends CommandTemplate {
 			@Argument.Define(argType = FloatArgumentType.class)
@@ -45,7 +42,7 @@ public class CmdTemplates {
 	@Command.Define(names = "cmd2")
 	public static class CmdTemplate2 extends CommandTemplate {
 		@Command.Define
-		public static class CmdTemplate2_1 extends CommandTemplate {}
+		public static class CmdTemplate2_1 extends CommandTemplate { }
 	}
 
 	@Command.Define
@@ -55,7 +52,6 @@ public class CmdTemplates {
 
 		@CommandAccessor
 		public CmdTemplate3_1 cmd2;
-
 
 		@Command.Define(names = "cmd3-1")
 		public static class CmdTemplate3_1 extends CommandTemplate {

--- a/src/test/java/lanat/test/units/commandTemplates/CmdTemplates.java
+++ b/src/test/java/lanat/test/units/commandTemplates/CmdTemplates.java
@@ -3,10 +3,12 @@ package lanat.test.units.commandTemplates;
 import lanat.Argument;
 import lanat.Command;
 import lanat.CommandTemplate;
+import lanat.ParsedArguments;
 import lanat.argumentTypes.BooleanArgumentType;
 import lanat.argumentTypes.FloatArgumentType;
 import lanat.argumentTypes.IntegerArgumentType;
 import lanat.argumentTypes.StringArgumentType;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
 
@@ -29,6 +31,7 @@ public class CmdTemplates {
 		@CommandAccessor
 		public CmdTemplate1_1 cmd2;
 
+
 		@Command.Define(names = "cmd1-1")
 		public static class CmdTemplate1_1 extends CommandTemplate {
 			@Argument.Define(argType = FloatArgumentType.class)
@@ -42,7 +45,7 @@ public class CmdTemplates {
 	@Command.Define(names = "cmd2")
 	public static class CmdTemplate2 extends CommandTemplate {
 		@Command.Define
-		public static class CmdTemplate2_1 extends CommandTemplate { }
+		public static class CmdTemplate2_1 extends CommandTemplate {}
 	}
 
 	@Command.Define
@@ -52,6 +55,7 @@ public class CmdTemplates {
 
 		@CommandAccessor
 		public CmdTemplate3_1 cmd2;
+
 
 		@Command.Define(names = "cmd3-1")
 		public static class CmdTemplate3_1 extends CommandTemplate {

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -6,7 +6,7 @@ module lanat.test {
 	requires textFormatter;
 
 	exports lanat.test to org.junit.platform.commons, lanat;
-	exports lanat.test.exampleTests to org.junit.platform.commons, lanat;
+	exports lanat.test.exampleTests to org.junit.platform.commons, lanat, utils;
 	exports lanat.test.units to lanat, org.junit.platform.commons;
 	exports lanat.test.units.commandTemplates to lanat, org.junit.platform.commons, utils;
 }


### PR DESCRIPTION
(Closes #18)

## Refactors
* Renamed `ParsedArguments` to `ParseResult`.

## Features
* Add `CommandTemplate#onValuesReceived()`, which gets called after the instantation of a Command Template, but only if the Command it belongs to was actually used by the user.
* Add `CommandTemplate#getParseResult()` and `CommandTemplate#getCommand()`, which provide access to the `ParseResult` and `Command` instances that were used to instantiate the template.
* Add a `wasUsed()` method to `ParseResult` and `CommandTemplate` to see if the underlying Command was used by the user.
* `ParseResult#getSubResult(String)` now returns a non-nullable type. If the command name specified doesnt exist, a exception is trhown instead.